### PR TITLE
Fix debuginfo packages.

### DIFF
--- a/configure
+++ b/configure
@@ -138,11 +138,8 @@ for infile in $infiles; do
         > $TOP_BUILDDIR/$infile
 done
 
-# run qmake
-qmake $relpath/contactsd.pro
-
 echo
-echo "contactsd is now configured for building. Just run 'make'."
+echo "contactsd is now configured for building. Now run 'qmake' and then 'make'."
 echo "Once everything is built, you must run 'make install'."
 echo "contactsd will be installed into $PREFIX"
 echo

--- a/rpm/contactsd.spec
+++ b/rpm/contactsd.spec
@@ -65,6 +65,7 @@ Requires: %{name} = %{version}-%{release}
 
 %build
 ./configure --bindir %{_bindir} --libdir %{_libdir} --includedir %{_includedir}
+%qmake
 make %{?_smp_mflags}
 
 


### PR DESCRIPTION
...o.

This uses the %qmake macro which sets up the appropriate cflags etcetera.
Without this, the compiler didn't pass -g, and thus we never got debuginfo
packages.
