### PR TITLE
[contactsd] Small bugfixes to setting up signal handlers

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -86,18 +86,18 @@ static void setupUnixSignalHandlers()
 
     sigterm.sa_handler = ContactsDaemon::unixSignalHandler;
     sigemptyset(&sigterm.sa_mask);
-    sigterm.sa_flags |= SA_RESTART;
+    sigterm.sa_flags = SA_RESTART;
 
-    if (sigaction(SIGTERM, &sigterm, 0) > 0) {
+    if (sigaction(SIGTERM, &sigterm, 0) < 0) {
         qWarning() << "Could not setup signal handler for SIGTERM";
         return;
     }
 
     sigint.sa_handler = ContactsDaemon::unixSignalHandler;
     sigemptyset(&sigint.sa_mask);
-    sigint.sa_flags |= SA_RESTART;
+    sigint.sa_flags = SA_RESTART;
 
-    if (sigaction(SIGINT, &sigint, 0) > 0) {
+    if (sigaction(SIGINT, &sigint, 0) < 0) {
         qWarning() << "Could not setup signal handler for SIGINT";
         return;
     }


### PR DESCRIPTION
setupUnixSignalHandlers() had a wrong check for the return value of sigaction(), and didn't initialize the sa_flags member.

I verified that this fixes the bug where it segfaults after getting a SIGTERM.
