### PR TITLE
[contactsd] Force the contacts backend selection in qt5

### DIFF
--- a/plugins/birthday/cdbirthdaycontroller.cpp
+++ b/plugins/birthday/cdbirthdaycontroller.cpp
@@ -51,7 +51,12 @@ CDBirthdayController::CDBirthdayController(QObject *parent)
     , mCalendar(0)
     , mManager(0)
 {
+#ifdef USING_QTPIM
+    // Temporary override until qtpim supports QTCONTACTS_MANAGER_OVERRIDE
+    mManager = new QContactManager(QStringLiteral("org.nemomobile.contacts.sqlite"), QMap<QString, QString>(), this);
+#else
     mManager = new QContactManager(this);
+#endif
 #ifdef USING_QTPIM
     connect(mManager, SIGNAL(contactsAdded(QList<QContactId>)),
             SLOT(contactsChanged(QList<QContactId>)));

--- a/plugins/telepathy/cdtpstorage.cpp
+++ b/plugins/telepathy/cdtpstorage.cpp
@@ -255,7 +255,12 @@ const QLatin1String QContactOnlineAccount__FieldEnabled("Enabled");
 
 QContactManager *manager()
 {
+#ifdef USING_QTPIM
+    // Temporary override until qtpim supports QTCONTACTS_MANAGER_OVERRIDE
+    static QContactManager *manager = new QContactManager(QStringLiteral("org.nemomobile.contacts.sqlite"));
+#else
     static QContactManager *manager = new QContactManager;
+#endif
     return manager;
 }
 

--- a/rpm/contactsd-qt5.spec
+++ b/rpm/contactsd-qt5.spec
@@ -1,5 +1,5 @@
 Name: contactsd-qt5
-Version: 1.4.0
+Version: 1.4.1
 Release: 1
 Summary: Telepathy <> QtContacts bridge for contacts
 Group: System/Libraries

--- a/rpm/contactsd.spec
+++ b/rpm/contactsd.spec
@@ -1,5 +1,5 @@
 Name: contactsd
-Version: 1.4.0
+Version: 1.4.1
 Release: 1
 Summary: Telepathy <> QtContacts bridge for contacts
 Group: System/Libraries

--- a/tests/ut_birthdayplugin/test-birthday-plugin.cpp
+++ b/tests/ut_birthdayplugin/test-birthday-plugin.cpp
@@ -69,7 +69,12 @@ TestBirthdayPlugin::TestBirthdayPlugin(QObject *parent) :
 
 void TestBirthdayPlugin::init()
 {
+#ifdef USING_QTPIM
+    // Temporary override until qtpim supports QTCONTACTS_MANAGER_OVERRIDE
+    mManager = new QContactManager(QStringLiteral("org.nemomobile.contacts.sqlite"));
+#else
     mManager = new QContactManager;
+#endif
 }
 
 void TestBirthdayPlugin::initTestCase()

--- a/tests/ut_telepathyplugin/test-telepathy-plugin.cpp
+++ b/tests/ut_telepathyplugin/test-telepathy-plugin.cpp
@@ -70,7 +70,12 @@ void TestTelepathyPlugin::initTestCase()
     dbus_g_bus_get(DBUS_BUS_STARTER, 0);
 
     /* Create a QContactManager and track added/changed contacts */
+#ifdef USING_QTPIM
+    // Temporary override until qtpim supports QTCONTACTS_MANAGER_OVERRIDE
+    mContactManager = new QContactManager(QStringLiteral("org.nemomobile.contacts.sqlite"));
+#else
     mContactManager = new QContactManager;
+#endif
 #ifdef USING_QTPIM
     connect(mContactManager,
             SIGNAL(contactsAdded(const QList<QContactId>&)),


### PR DESCRIPTION
qtpim does not yet support the QTCONTACTS_MANAGER_OVERRIDE mechanism
for selecting the default contacts backend.
