### PR TITLE
[contactsd] Fix a crash in the birthday plugin.

### DIFF
--- a/plugins/birthday/cdbirthdaycontroller.cpp
+++ b/plugins/birthday/cdbirthdaycontroller.cpp
@@ -269,7 +269,7 @@ CDBirthdayController::processFetchRequest(QContactFetchRequest *const fetchReque
 }
 
 #ifdef USING_QTPIM
-const QContactId &apiId(const QContact &contact) { return contact.id(); }
+QContactId apiId(const QContact &contact) { return contact.id(); }
 #else
 QContactLocalId apiId(const QContact &contact) { return contact.localId(); }
 #endif


### PR DESCRIPTION
QContactId is not a basic type, and QContact::id returns a QContactId (not a
ref), so this is essentially returning a ref to a temporary, even though the
compiler doesn't feel it needs to warn for some reason.
