### PR TITLE
[contactsd] Export symbols from main binary for plugins

### DIFF
--- a/src/base-plugin.h
+++ b/src/base-plugin.h
@@ -35,7 +35,7 @@
 namespace Contactsd
 {
 
-class BasePlugin : public QObject
+class Q_DECL_EXPORT BasePlugin : public QObject
 {
     Q_OBJECT
 

--- a/src/contactsd.h
+++ b/src/contactsd.h
@@ -30,7 +30,7 @@
 
 class ContactsdPluginLoader;
 
-class ContactsDaemon : public QObject
+class Q_DECL_EXPORT ContactsDaemon : public QObject
 {
     Q_OBJECT
 

--- a/src/contactsdpluginloader.h
+++ b/src/contactsdpluginloader.h
@@ -35,7 +35,7 @@ class QPluginLoader;
 class QString;
 class QStringList;
 
-class ContactsdPluginLoader : public QObject
+class Q_DECL_EXPORT ContactsdPluginLoader : public QObject
 {
     Q_OBJECT
 

--- a/src/debug.h
+++ b/src/debug.h
@@ -27,10 +27,10 @@
 namespace Contactsd
 {
 
-void enableDebug(bool enable);
-void enableWarnings(bool enable);
-bool isDebugEnabled();
-bool isWarningsEnabled();
+Q_DECL_EXPORT void enableDebug(bool enable);
+Q_DECL_EXPORT void enableWarnings(bool enable);
+Q_DECL_EXPORT bool isDebugEnabled();
+Q_DECL_EXPORT bool isWarningsEnabled();
 
 class Debug
 {
@@ -103,8 +103,8 @@ private:
 
 // The telepathy-farsight Qt 4 binding links to these - they're not API outside
 // this source tarball, but they *are* ABI
-Debug enabledDebug();
-Debug enabledWarning();
+Q_DECL_EXPORT Debug enabledDebug();
+Q_DECL_EXPORT Debug enabledWarning();
 
 #ifdef ENABLE_DEBUG
 

--- a/src/importstate.h
+++ b/src/importstate.h
@@ -29,7 +29,7 @@
 #include <QStringList>
 #include <QSettings>
 
-class ImportState
+class Q_DECL_EXPORT ImportState
 {
 public:
     ImportState();


### PR DESCRIPTION
Regression from e7005138d3c25146dcff4be8b7ee6a37e174e286, which
implicitly added hidden visibility flags.
