### PR TITLE
[contactsd] Simplify avatar processing

### DIFF
--- a/plugins/telepathy/cdtpavatarupdate.h
+++ b/plugins/telepathy/cdtpavatarupdate.h
@@ -42,6 +42,7 @@ public:
 
     explicit CDTpAvatarUpdate(QNetworkReply *networkReply,
                               CDTpContact *contactWrapper,
+                              const QString &filename,
                               const QString &avatarType,
                               QObject *parent = 0);
 
@@ -62,6 +63,7 @@ private:
 private:
     QPointer<QNetworkReply> mNetworkReply;
     QPointer<CDTpContact> mContactWrapper;
+    const QString mFilename;
     const QString mAvatarType;
     const QDir mCacheDir;
     QString mAvatarPath;


### PR DESCRIPTION
We only need to store one avatar per contact, preferably the large
variant.  Also modify the stored path to match that produced by
libsocialcache so that we will not duplicate identical avatars.
