### PR TITLE
[contactsd] Store account and provider display names on contacts

### DIFF
--- a/plugins/telepathy/cdtpaccount.h
+++ b/plugins/telepathy/cdtpaccount.h
@@ -71,6 +71,8 @@ public:
     QHash<QString, CDTpContact::Info> rosterCache() const;
     void setRosterCache(const QHash<QString, CDTpContact::Info> &rosterCache);
 
+    bool isReady() const { return mReady; }
+
     QVariantMap storageInfo() const;
 
 Q_SIGNALS:
@@ -82,6 +84,7 @@ Q_SIGNALS:
     void rosterContactChanged(CDTpContactPtr contactWrapper, CDTpContact::Changes changes);
     void syncStarted(Tp::AccountPtr account);
     void syncEnded(Tp::AccountPtr account, int contactsAdded, int contactsRemoved);
+    void readyChanged();
 
 private Q_SLOTS:
     void onAccountDisplayNameChanged();
@@ -104,6 +107,7 @@ private:
     CDTpContactPtr insertContact(const Tp::ContactPtr &contact);
     void maybeRequestExtraInfo(Tp::ContactPtr contact);
     void makeRosterCache();
+    void setReady();
 
 private:
     Tp::AccountPtr mAccount;
@@ -114,6 +118,7 @@ private:
     QHash<QString, CDTpContact::Info> mRosterCache;
     QStringList mContactsToAvoid;
     QTimer mDisconnectTimeout;
+    bool mReady;
     bool mHasRoster;
     bool mNewAccount;
     bool mImporting;

--- a/plugins/telepathy/cdtpstorage.h
+++ b/plugins/telepathy/cdtpstorage.h
@@ -75,6 +75,9 @@ public:
 private Q_SLOTS:
     void onUpdateQueueTimeout();
 
+    void addNewAccount();
+    void updateAccount();
+
 private:
     void cancelQueuedUpdates(const QList<CDTpContactPtr> &contacts);
 


### PR DESCRIPTION
Requires https://github.com/nemomobile/telepathy-accounts-signon/pull/10

Store the account and provider display names from Telepathy in new fields of QContactOnlineAccount. That gives UI everything it needs for a good presentation of accounts without dipping into libaccounts or telepathy.

In the current implementation, these fields are added on all accounts, both self and remote. That should be okay as long as we're properly avoiding unnecessary changes after the startup sync.

So, we're doing extra changes after the startup sync. Currently, the storage info arrives later than the rest of the account info, and results in a second set of contact updates at startup. I will try to resolve that in another commit before merging, so consider this a pre-review.
