### PR TITLE
[contactsd] Add voicemail contact if configured

### DIFF
--- a/plugins/sim/cdsimcontroller.h
+++ b/plugins/sim/cdsimcontroller.h
@@ -29,6 +29,9 @@
 
 #include <qofonophonebook.h>
 #include <qofonosimmanager.h>
+#include <qofonomessagewaiting.h>
+
+#include <MGConfItem>
 
 #ifdef USING_QTPIM
 QTCONTACTS_USE_NAMESPACE
@@ -63,11 +66,13 @@ public Q_SLOTS:
     void contactIdsAvailable();
     void requestStateChanged(QContactAbstractRequest::State state);
     void contactsAvailable();
+    void voicemailConfigurationChanged();
 
 private:
     void setBusy(bool busy);
     void removeAllSimContacts();
     void ensureSimContactsPresent();
+    void updateVoicemailConfiguration();
 
 private:
     QContactManager m_manager;
@@ -84,11 +89,14 @@ private:
     QString m_syncTarget;
     QString m_modemPath;
     QOfonoPhonebook m_phonebook;
+    QOfonoMessageWaiting m_messageWaiting;
 
     QSet<QContactId> m_contactIds;
     QList<QContact> m_contacts;
     QList<QContact> m_simContacts;
     bool m_busy;
+
+    MGConfItem *m_voicemailConf;
 };
 
 #endif // CDSIMCONTROLLER_H

--- a/plugins/sim/sim.pro
+++ b/plugins/sim/sim.pro
@@ -5,7 +5,7 @@ QT += dbus
 CONFIG += plugin
 
 CONFIG += link_pkgconfig
-PKGCONFIG += Qt5Contacts Qt5Versit qofono-qt5
+PKGCONFIG += mlite5 Qt5Contacts Qt5Versit qofono-qt5
 DEFINES *= USING_QTPIM
 
 DEFINES += QT_NO_CAST_TO_ASCII QT_NO_CAST_FROM_ASCII

--- a/tests/ut_simplugin/ut_simplugin.pro
+++ b/tests/ut_simplugin/ut_simplugin.pro
@@ -9,7 +9,7 @@ QT -= gui
 QT += dbus testlib
 DEFINES += ENABLE_DEBUG
 
-PKGCONFIG += Qt5Contacts Qt5Versit qofono-qt5
+PKGCONFIG += mlite5 Qt5Contacts Qt5Versit qofono-qt5
 DEFINES *= USING_QTPIM
 
 INCLUDEPATH += \


### PR DESCRIPTION
If a number has been configured as the voicemail access number, either manually or by the system, create a contact to represent that number.
