### PR TITLE
[contactsd] Improve sim contacts import logic

### DIFF
--- a/tests/ut_simplugin/test-sim-plugin.h
+++ b/tests/ut_simplugin/test-sim-plugin.h
@@ -39,6 +39,8 @@ private Q_SLOTS:
     void testAddAndRemove();
     void testChangedNumber();
     void testMultipleNumbers();
+    void testMultipleIdenticalNumbers();
+    void testTrimWhitespace();
     void testEmpty();
     void testClear();
 


### PR DESCRIPTION
This commit ensures that sim contact nicknames are trimmed prior to
being compared with device contacts, or stored as device contacts,
to ensure that round-trips don't cause duplication due to automatic
whitespace trimming which the qtcontacts-sqlite engine does by default.

It also ensures that we only save numbers from sim contacts into the
associated device contact if the number is unique within that contact,
to ensure that round-trips don't cause duplication if a sim contact
has multiple identical phone numbers in its record.
