### PR TITLE
[contactsd] Coalesce identical sim contacts to avoid duplication

### DIFF
--- a/tests/ut_simplugin/test-sim-plugin.h
+++ b/tests/ut_simplugin/test-sim-plugin.h
@@ -41,6 +41,7 @@ private Q_SLOTS:
     void testMultipleNumbers();
     void testMultipleIdenticalNumbers();
     void testTrimWhitespace();
+    void testCoalescing();
     void testEmpty();
     void testClear();
 


### PR DESCRIPTION
This commit coalesces sim contacts with identical display names
to avoid adding duplicates to the local device store.
