### PR TITLE
[contactsd] Allow disabling transient SIM contact import.

### DIFF
--- a/plugins/sim/cdsimcontroller.h
+++ b/plugins/sim/cdsimcontroller.h
@@ -67,12 +67,14 @@ public Q_SLOTS:
     void requestStateChanged(QContactAbstractRequest::State state);
     void contactsAvailable();
     void voicemailConfigurationChanged();
+    void transientImportConfigurationChanged();
 
 private:
     void setBusy(bool busy);
     void removeAllSimContacts();
     void ensureSimContactsPresent();
     void updateVoicemailConfiguration();
+    void performTransientImport();
 
 private:
     QContactManager m_manager;
@@ -85,6 +87,7 @@ private:
 
     QOfonoSimManager m_simManager;
     bool m_simPresent;
+    bool m_transientImport;
 
     QString m_syncTarget;
     QString m_modemPath;
@@ -97,6 +100,7 @@ private:
     bool m_busy;
 
     MGConfItem *m_voicemailConf;
+    MGConfItem m_transientImportConf;
 };
 
 #endif // CDSIMCONTROLLER_H


### PR DESCRIPTION
This commit now changes the behaviour of the sim plugin depending
on the value of a configuration value.  If the value is "1"
then the sim plugin will transiently import sim contacts into
the phone addressbook automatically, otherwise it will not.
The default value assumed for the setting if it does not exist
is "1".
