### PR TITLE
[contactsd-birthday-plugin] Disallow modifying and creating event to birthday calendar by calendar application.

### DIFF
--- a/plugins/birthday/cdbirthdaycalendar.h
+++ b/plugins/birthday/cdbirthdaycalendar.h
@@ -93,6 +93,7 @@ private:
     static QString calendarEventId(ContactIdType contactId);
 
     KCalCore::Event::Ptr calendarEvent(ContactIdType contactId);
+    void setReadOnly(bool readOnly, bool save = false);
 
 private Q_SLOTS:
     void onLocaleChanged();


### PR DESCRIPTION
Since mkcal sqlite backend does not store event::isReadOnly state, notebooks readonly used instead.
