### PR TITLE
[contactsd] Also tokenise SIM contact name

### DIFF
--- a/plugins/sim/cdsimcontroller.cpp
+++ b/plugins/sim/cdsimcontroller.cpp
@@ -16,6 +16,7 @@
 #include "cdsimcontroller.h"
 #include "cdsimplugin.h"
 #include "debug.h"
+#include "util.h"
 
 #include <QContactDetailFilter>
 #include <QContactNickname>
@@ -73,9 +74,9 @@ CDSimController::CDSimController(QObject *parent)
     connect(&m_fetchIdsRequest, SIGNAL(stateChanged(QContactAbstractRequest::State)),
             this, SLOT(requestStateChanged(QContactAbstractRequest::State)));
 
-    // Fetch only the nickname and phone details for imported contacts
+    // Fetch only the name, nickname and phone details for imported contacts
     QContactFetchHint hint;
-    hint.setDetailTypesHint(QList<QContactDetail::DetailType>() << QContactNickname::Type << QContactPhoneNumber::Type);
+    hint.setDetailTypesHint(QList<QContactDetail::DetailType>() << QContactName::Type << QContactNickname::Type << QContactPhoneNumber::Type);
     hint.setOptimizationHints(QContactFetchHint::NoRelationships | QContactFetchHint::NoActionPreferences | QContactFetchHint::NoBinaryBlobs);
     m_fetchRequest.setFetchHint(hint);
 
@@ -413,7 +414,12 @@ void CDSimController::ensureSimContactsPresent()
         } else {
             // We need to import this contact
 
-            // Convert the display label to a nickname; display label is managed by the backend
+            // Convert the display label to a name, and store the imported
+            // display label as the nickname; display label is managed by the backend
+            QContactName name = simContact.detail<QContactName>();
+            Util::decomposeNameDetails(displayLabel.label().trimmed(), &name);
+            simContact.saveDetail(&name);
+
             QContactNickname nickname = simContact.detail<QContactNickname>();
             nickname.setNickname(displayLabel.label().trimmed());
             simContact.saveDetail(&nickname);

--- a/plugins/telepathy/cdtpstorage.cpp
+++ b/plugins/telepathy/cdtpstorage.cpp
@@ -62,6 +62,7 @@
 #include "cdtpavatarupdate.h"
 #include "cdtpplugin.h"
 #include "debug.h"
+#include "util.h"
 
 #include <QElapsedTimer>
 
@@ -1060,16 +1061,6 @@ const QString &protocolType(const QString &protocol)
 #endif
 
 template<typename F1, typename F2>
-void updateNameDetail(F1 getter, F2 setter, QContactName *nameDetail, const QString &value)
-{
-    QString existing((nameDetail->*getter)());
-    if (!existing.isEmpty()) {
-        existing.append(QChar::fromLatin1(' '));
-    }
-    (nameDetail->*setter)(existing + value);
-}
-
-template<typename F1, typename F2>
 void replaceNameDetail(F1 getter, F2 setter, QContactName *nameDetail, const QString &value)
 {
     if (!value.isEmpty()) {
@@ -1083,56 +1074,7 @@ void replaceNameDetail(F1 getter, F2 setter, QContactName *nameDetail, const QSt
     }
 }
 
-void decomposeNameDetails(const QString &formattedName, QContactName *nameDetail)
-{
-    // Try to parse the structure from the formatted name
-    // TODO: Use MBreakIterator for localized splitting
-    QStringList tokens(formattedName.split(QChar::fromLatin1(' '), QString::SkipEmptyParts));
-    if (tokens.count() >= 2) {
-        QString format;
-        if (tokens.count() == 2) {
-            //: Format string for allocating 2 tokens to name parts - 2 characters from the set [FMLPS]
-            //% "FL"
-            format = qtTrId("qtn_name_structure_2_tokens");
-        } else if (tokens.count() == 3) {
-            //: Format string for allocating 3 tokens to name parts - 3 characters from the set [FMLPS]
-            //% "FML"
-            format = qtTrId("qtn_name_structure_3_tokens");
-        } else if (tokens.count() > 3) {
-            //: Format string for allocating 4 tokens to name parts - 4 characters from the set [FMLPS]
-            //% "FFML"
-            format = qtTrId("qtn_name_structure_4_tokens");
 
-            // Coalesce the leading tokens together to limit the possibilities
-            int excess = tokens.count() - 4;
-            if (excess > 0) {
-                QString first(tokens.takeFirst());
-                while (--excess >= 0) {
-                    // TODO: local-specific join?
-                    first += QChar::fromLatin1(' ') + tokens.takeFirst();
-                }
-                tokens.prepend(first);
-            }
-        }
-
-        if (format.length() != tokens.length()) {
-            qWarning() << "Invalid structure format for" << tokens.count() << "tokens:" << format;
-        } else {
-            foreach (const QChar &part, format) {
-                const QString token(tokens.takeFirst());
-                switch (part.toUpper().toLatin1()) {
-                    case 'F': updateNameDetail(&QContactName::firstName, &QContactName::setFirstName, nameDetail, token); break;
-                    case 'M': updateNameDetail(&QContactName::middleName, &QContactName::setMiddleName, nameDetail, token); break;
-                    case 'L': updateNameDetail(&QContactName::lastName, &QContactName::setLastName, nameDetail, token); break;
-                    case 'P': updateNameDetail(&QContactName::prefix, &QContactName::setPrefix, nameDetail, token); break;
-                    case 'S': updateNameDetail(&QContactName::suffix, &QContactName::setSuffix, nameDetail, token); break;
-                    default:
-                        qWarning() << "Invalid structure format character:" << part;
-                }
-            }
-        }
-    }
-}
 
 template<typename T, typename F>
 bool detailListsDiffer(const QList<T> &lhs, const QList<T> &rhs, F detailsDiffer)
@@ -1485,7 +1427,7 @@ CDTpContact::Changes updateContactDetails(QNetworkAccessManager &network, QConta
 
                 if (structuredName || !formattedName.isEmpty()) {
                     if (!structuredName) {
-                        decomposeNameDetails(formattedName, &nameDetail);
+                        Util::decomposeNameDetails(formattedName, &nameDetail);
                     }
 
                     if (!formattedName.isEmpty()) {
@@ -1909,7 +1851,7 @@ bool CDTpStorage::initializeNewContact(QContact &newContact, CDTpAccountPtr acco
     if (!alias.isEmpty()) {
         QContactName name;
 
-        decomposeNameDetails(alias, &name);
+        Util::decomposeNameDetails(alias, &name);
 
 #ifdef USING_QTPIM
         name.setValue(QContactName__FieldCustomLabel, alias);

--- a/src/src.pro
+++ b/src/src.pro
@@ -38,6 +38,8 @@ TRANSLATIONS_INSTALL_PATH = "/usr/share/translations"
 DEFINES += TRANSLATIONS_INSTALL_PATH=\"\\\"\"$${TRANSLATIONS_INSTALL_PATH}\"\\\"\"
 
 CONFIG += link_pkgconfig
+PKGCONFIG += Qt5Contacts
+DEFINES *= USING_QTPIM
 packagesExist(qt5-boostable) {
     DEFINES += HAS_BOOSTER
     PKGCONFIG += qt5-boostable
@@ -51,6 +53,7 @@ HEADERS += contactsd.h \
     importstateconst.h \
     contactsimportprogressadaptor.h \
     debug.h \
+    util.h \
     base-plugin.h
 
 SOURCES += main.cpp \
@@ -59,6 +62,7 @@ SOURCES += main.cpp \
     importstate.cpp \
     contactsimportprogressadaptor.cpp \
     debug.cpp \
+    util.cpp \
     base-plugin.cpp
 
 DEFINES += VERSION=\\\"$${VERSION}\\\"
@@ -67,6 +71,7 @@ DEFINES += CONTACTSD_PLUGINS_DIR=\\\"$$LIBDIR/$${VERSIONED_TARGET}/plugins\\\"
 
 headers.files = BasePlugin base-plugin.h \
     Debug debug.h \
+    Util util.h \
     ImportStateConst importstateconst.h
 headers.path = $$INCLUDEDIR/$${VERSIONED_TARGET}/Contactsd
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1,0 +1,80 @@
+/** This file is part of Contacts daemon
+ **
+ ** Copyright (c) 2014 Jolla Ltd.
+ ** Contact: Chris Adams <chris.adams@jolla.com>
+ **
+ ** GNU Lesser General Public License Usage
+ ** This file may be used under the terms of the GNU Lesser General Public License
+ ** version 2.1 as published by the Free Software Foundation and appearing in the
+ ** file LICENSE.LGPL included in the packaging of this file.  Please review the
+ ** following information to ensure the GNU Lesser General Public License version
+ ** 2.1 requirements will be met:
+ ** http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+ **/
+
+#include "util.h"
+#include "debug.h"
+
+#include <QStringList>
+#include <QChar>
+
+template<typename F1, typename F2>
+void updateNameDetail(F1 getter, F2 setter, QContactName *nameDetail, const QString &value)
+{
+    QString existing((nameDetail->*getter)());
+    if (!existing.isEmpty()) {
+        existing.append(QChar::fromLatin1(' '));
+    }
+    (nameDetail->*setter)(existing + value);
+}
+
+void Contactsd::Util::decomposeNameDetails(const QString &formattedName, QContactName *nameDetail)
+{
+    // Try to parse the structure from the formatted name
+    // TODO: Use MBreakIterator for localized splitting
+    QStringList tokens(formattedName.split(QChar::fromLatin1(' '), QString::SkipEmptyParts));
+    if (tokens.count() >= 2) {
+        QString format;
+        if (tokens.count() == 2) {
+            //: Format string for allocating 2 tokens to name parts - 2 characters from the set [FMLPS]
+            //% "FL"
+            format = qtTrId("qtn_name_structure_2_tokens");
+        } else if (tokens.count() == 3) {
+            //: Format string for allocating 3 tokens to name parts - 3 characters from the set [FMLPS]
+            //% "FML"
+            format = qtTrId("qtn_name_structure_3_tokens");
+        } else if (tokens.count() > 3) {
+            //: Format string for allocating 4 tokens to name parts - 4 characters from the set [FMLPS]
+            //% "FFML"
+            format = qtTrId("qtn_name_structure_4_tokens");
+
+            // Coalesce the leading tokens together to limit the possibilities
+            int excess = tokens.count() - 4;
+            if (excess > 0) {
+                QString first(tokens.takeFirst());
+                while (--excess >= 0) {
+                    // TODO: locale-specific join?
+                    first += QChar::fromLatin1(' ') + tokens.takeFirst();
+                }
+                tokens.prepend(first);
+            }
+        }
+
+        if (format.length() != tokens.length()) {
+            qWarning() << "Invalid structure format for" << tokens.count() << "tokens:" << format;
+        } else {
+            Q_FOREACH (const QChar &part, format) {
+                const QString token(tokens.takeFirst());
+                switch (part.toUpper().toLatin1()) {
+                    case 'F': updateNameDetail(&QContactName::firstName, &QContactName::setFirstName, nameDetail, token); break;
+                    case 'M': updateNameDetail(&QContactName::middleName, &QContactName::setMiddleName, nameDetail, token); break;
+                    case 'L': updateNameDetail(&QContactName::lastName, &QContactName::setLastName, nameDetail, token); break;
+                    case 'P': updateNameDetail(&QContactName::prefix, &QContactName::setPrefix, nameDetail, token); break;
+                    case 'S': updateNameDetail(&QContactName::suffix, &QContactName::setSuffix, nameDetail, token); break;
+                    default:
+                        qWarning() << "Invalid structure format character:" << part;
+                }
+            }
+        }
+    }
+}

--- a/src/util.h
+++ b/src/util.h
@@ -1,0 +1,38 @@
+/** This file is part of Contacts daemon
+ **
+ ** Copyright (c) 2014 Jolla Ltd.
+ ** Contact: Chris Adams <chris.adams@jolla.com>
+ **
+ ** GNU Lesser General Public License Usage
+ ** This file may be used under the terms of the GNU Lesser General Public License
+ ** version 2.1 as published by the Free Software Foundation and appearing in the
+ ** file LICENSE.LGPL included in the packaging of this file.  Please review the
+ ** following information to ensure the GNU Lesser General Public License version
+ ** 2.1 requirements will be met:
+ ** http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+ **/
+
+#ifndef UTIL_H
+#define UTIL_H
+
+#include <QString>
+
+#include <QContact>
+#include <QContactName>
+
+#ifdef USING_QTPIM
+QTCONTACTS_USE_NAMESPACE
+#else
+QTM_USE_NAMESPACE
+#endif
+
+namespace Contactsd
+{
+    class Util {
+    public:
+        Q_DECL_EXPORT static void decomposeNameDetails(const QString &formattedName,
+                                                       QContactName *nameDetail);
+    };
+}
+
+#endif // UTIL_H

--- a/tests/ut_contactsd/ut_contactsd.pro
+++ b/tests/ut_contactsd/ut_contactsd.pro
@@ -43,6 +43,7 @@ HEADERS += test-contactsd.h \
     $$TOP_SOURCEDIR/src/contactsdpluginloader.h \
     $$TOP_SOURCEDIR/src/importstate.h \
     $$TOP_SOURCEDIR/src/debug.h \
+    $$TOP_SOURCEDIR/src/util.h \
     $$TOP_SOURCEDIR/src/base-plugin.h
 
 SOURCES += test-contactsd.cpp \
@@ -50,6 +51,7 @@ SOURCES += test-contactsd.cpp \
     $$TOP_SOURCEDIR/src/contactsdpluginloader.cpp \
     $$TOP_SOURCEDIR/src/importstate.cpp \
     $$TOP_SOURCEDIR/src/debug.cpp \
+    $$TOP_SOURCEDIR/src/util.cpp \
     $$TOP_SOURCEDIR/src/base-plugin.cpp
 
 DEFINES += CONTACTSD_PLUGINS_DIR=\\\"$$LIBDIR/$${PACKAGENAME}-1.0/plugins\\\"

--- a/tests/ut_simplugin/ut_simplugin.pro
+++ b/tests/ut_simplugin/ut_simplugin.pro
@@ -18,10 +18,12 @@ INCLUDEPATH += \
 
 HEADERS += \
     test-sim-plugin.h \
-    ../../plugins/sim/cdsimcontroller.h
+    ../../plugins/sim/cdsimcontroller.h \
+    ../../src/util.h
 
 SOURCES += \
     test-sim-plugin.cpp \
-    ../../plugins/sim/cdsimcontroller.cpp
+    ../../plugins/sim/cdsimcontroller.cpp \
+    ../../src/util.cpp
 
 INSTALLS += target

--- a/tests/ut_telepathyplugin/ut_telepathyplugin.pro
+++ b/tests/ut_telepathyplugin/ut_telepathyplugin.pro
@@ -56,13 +56,17 @@ QMAKE_CXXFLAGS += -c -g --coverage -ftest-coverage -fprofile-arcs
 LIBS += -lgcov
 }
 
-HEADERS += debug.h \
+HEADERS += \
+    $$TOP_SOURCEDIR/src/util.h \
+    debug.h \
     test-telepathy-plugin.h \
     test-expectation.h \
     test.h \
     buddymanagementinterface.h
 
-SOURCES += debug.cpp \
+SOURCES += \
+    $$TOP_SOURCEDIR/src/util.cpp \
+    debug.cpp \
     test-telepathy-plugin.cpp \
     test-expectation.cpp \
     test.cpp \


### PR DESCRIPTION
Previously, only display labels received from XMPP contacts were
tokenised (via locale-specific heuristics) into structured name
fields.  This commit hoists that logic into a util file and uses
that from both the SIM and XMPP (telepathy) plugins.