### PR TITLE
[contactsd] Deactivate contacts on SIM removal

### DIFF
--- a/plugins/sim/cdsimcontroller.h
+++ b/plugins/sim/cdsimcontroller.h
@@ -64,11 +64,14 @@ public Q_SLOTS:
 
 private:
     void setBusy(bool busy);
+    void deactivateAllSimContacts();
     void removeAllSimContacts();
     void ensureSimContactsPresent();
     void updateVoicemailConfiguration();
     void performTransientImport();
+
     QContactDetailFilter simSyncTargetFilter() const;
+    QContactFilter deactivatedFilter() const;
 
 private:
     QContactManager m_manager;

--- a/plugins/sim/sim.pro
+++ b/plugins/sim/sim.pro
@@ -6,6 +6,7 @@ CONFIG += plugin
 
 CONFIG += link_pkgconfig
 PKGCONFIG += mlite5 Qt5Contacts Qt5Versit qofono-qt5
+PKGCONFIG += qtcontacts-sqlite-qt5-extensions
 DEFINES *= USING_QTPIM
 
 DEFINES += QT_NO_CAST_TO_ASCII QT_NO_CAST_FROM_ASCII

--- a/tests/ut_simplugin/ut_simplugin.pro
+++ b/tests/ut_simplugin/ut_simplugin.pro
@@ -10,6 +10,7 @@ QT += dbus testlib
 DEFINES += ENABLE_DEBUG
 
 PKGCONFIG += mlite5 Qt5Contacts Qt5Versit qofono-qt5
+PKGCONFIG += qtcontacts-sqlite-qt5-extensions
 DEFINES *= USING_QTPIM
 
 INCLUDEPATH += \


### PR DESCRIPTION
Rather than deleting SIM contacts when the SIM is removed, contacts
read from the SIM should be deactivated.  Then if the SIM is later
reinserted, they can be reactivated, maintaining any relationships
they previously participated in.
