### PR TITLE
[telepathy-plugin] Improve queued contact changeset binning

### DIFF
--- a/plugins/telepathy/cdtpstorage.cpp
+++ b/plugins/telepathy/cdtpstorage.cpp
@@ -1959,16 +1959,17 @@ void CDTpStorage::updateContactChanges(CDTpContactPtr contactWrapper, CDTpContac
             removeList->append(apiId(existing));
         }
     } else {
+        bool needAllChanges = false;
         if (existing.isEmpty()) {
             if (!initializeNewContact(existing, contactWrapper)) {
                 warning() << SRC_LOC << "Unable to create contact for account:" << accountPath << contactAddress;
                 return;
             }
-            changes |= CDTpContact::All;
+            needAllChanges = true;
         }
 
         changes = updateContactDetails(mNetwork, existing, contactWrapper, changes);
-
+        if (needAllChanges) changes = CDTpContact::All;
         appendContactChange(saveSet, existing, changes);
     }
 }


### PR DESCRIPTION
This commit ensures that if a queued contact change results in a new
contact being added, that the newly initialized contact is added to
the "All Changes" changeset bin of the contact save set.
This has the effect that any details generated during initialization
of the new contact (such as decomposed name details) will be stored
for the contact.
