### PR TITLE
[contactsd] Do not abort export sync if updates are applied

### DIFF
--- a/plugins/exporter/cdexportercontroller.cpp
+++ b/plugins/exporter/cdexportercontroller.cpp
@@ -627,7 +627,14 @@ private:
                         continue;
                     }
                 }
+
                 qWarning() << "Unable to remove privileged DB deletions from export DB!";
+
+                // Removing contacts is less important than updating - if we can perform updates,
+                // then failure to remove should not abort the sync attempt
+                if (!modifiedContacts.isEmpty()) {
+                    break;
+                }
                 return false;
             }
         }
@@ -653,8 +660,8 @@ private:
 
         if (!selfContact.id().isNull()) {
             if (!m_nonprivileged.saveContact(&selfContact)) {
+                // Do not abort the sync attempt for this error
                 qWarning() << "Unable to save privileged DB self contact changes to export DB!";
-                return false;
             }
         }
 


### PR DESCRIPTION
The export plugin does not apply changes transactionally; we should
not abort a sync if some changes have been applied, since partial
changes will then accumulate.

If add/modify changes are successfully applied, then do not abort
sync because removals fail, or because the self contact cannot be
updated.
