### PR TITLE
[contactsd] By default suppress import from export DB

### DIFF
--- a/plugins/exporter/cdexportercontroller.h
+++ b/plugins/exporter/cdexportercontroller.h
@@ -61,6 +61,7 @@ private:
 
     MGConfItem m_disabledConf;
     MGConfItem m_debugConf;
+    MGConfItem m_importConf;
 };
 
 #endif // CDEXPORTERCONTROLLER_H


### PR DESCRIPTION
Import of changes applied to the export database is currently an unnecessary complication.  Unless the '/org/nemomobile/contacts/export/import' configuration variable is non-zero, do not import theses changes.
