### PR TITLE
Optimize contacts export to reduce ineffective effort

### DIFF
--- a/plugins/exporter/cdexportercontroller.cpp
+++ b/plugins/exporter/cdexportercontroller.cpp
@@ -440,7 +440,7 @@ private:
             return false;
         }
 
-        if (!readSyncStateData(&m_remoteSince, m_accountId)) {
+        if (!readSyncStateData(&m_remoteSince, m_accountId, TwoWayContactSyncAdapter::ReadPartialState)) {
             qWarning() << "Unable to read sync state data";
             return false;
         }


### PR DESCRIPTION
Ensure that the exporter requires the minimal amount of effort in processing events where contacts are not actually modified.
