### PR TITLE
[contactsd] Disconnect handlers after use

### DIFF
--- a/plugins/telepathy/cdtpstorage.h
+++ b/plugins/telepathy/cdtpstorage.h
@@ -103,6 +103,7 @@ private:
     QHash<CDTpContactPtr, CDTpContact::Changes> mUpdateQueue;
     QTimer mUpdateTimer;
     QElapsedTimer mWaitTimer;
+    QMap<QString, CDTpAccount::Changes> m_accountPendingChanges;
 };
 
 #endif // CDTPSTORAGE_H


### PR DESCRIPTION
Ensure that we do not process ready-changed handlers repeatedly.
