### PR TITLE
Fix modem list query

### DIFF
--- a/plugins/sim/cdsimcontroller.h
+++ b/plugins/sim/cdsimcontroller.h
@@ -1,6 +1,6 @@
 /** This file is part of Contacts daemon
  **
- ** Copyright (c) 2013 Jolla Ltd.
+ ** Copyright (c) 2013-2014 Jolla Ltd.
  **
  ** Contact: Matt Vogt <matthew.vogt@jollamobile.com>
  **
@@ -42,13 +42,13 @@ class CDSimController : public QObject
 {
     Q_OBJECT
 
+
+
 public:
     explicit CDSimController(QObject *parent = 0, const QString &syncTarget = QString::fromLatin1("sim"));
     ~CDSimController();
 
     QContactManager &contactManager();
-
-    void setModemPath(const QString &path);
 
     bool busy() const;
 
@@ -56,16 +56,17 @@ Q_SIGNALS:
     void busyChanged(bool);
 
 public Q_SLOTS:
+    void setModemPath(const QString &path);
     void simPresenceChanged(bool present);
     void vcardDataAvailable(const QString &vcardData);
     void vcardReadFailed();
     void readerStateChanged(QVersitReader::State state);
     void voicemailConfigurationChanged();
     void transientImportConfigurationChanged();
-    void interfacesChanged(const QStringList &interfaces);
+    void phoneBookAvailabilityChanged(bool available);
 
 private:
-    void setBusy(bool busy);
+    void updateBusy();
     void deactivateAllSimContacts();
     void removeAllSimContacts();
     void ensureSimContactsPresent();
@@ -80,13 +81,9 @@ private:
     QVersitReader m_contactReader;
 
     QOfonoSimManager m_simManager;
-    bool m_simPresent;
     bool m_transientImport;
-    bool m_phonebookAvailable;
 
     QString m_simSyncTarget;
-    QString m_modemPath;
-    QOfonoModem m_modem;
     QOfonoPhonebook m_phonebook;
     QOfonoMessageWaiting m_messageWaiting;
 

--- a/plugins/sim/cdsimplugin.cpp
+++ b/plugins/sim/cdsimplugin.cpp
@@ -1,6 +1,6 @@
 /** This file is part of Contacts daemon
  **
- ** Copyright (c) 2013 Jolla Ltd.
+ ** Copyright (c) 2013-2014 Jolla Ltd.
  **
  ** Contact: Matt Vogt <matthew.vogt@jollamobile.com>
  **
@@ -36,14 +36,14 @@ void CDSimPlugin::init()
 
     mController = new CDSimController(this);
 
-    QOfonoManager ofonoManager;
-    const QStringList &modems(ofonoManager.modems());
-    if (modems.isEmpty()) {
-        qWarning() << "No modem available for sim plugin";
-    } else {
-        // TODO: select the correct modem
-        mController->setModemPath(modems.first());
-    }
+    // Associate CDSimController with the default modem
+    // NB: Expect this to happen asynchronously, as a result of receiving
+    // defaultModemChanged signal.
+    QOfonoManager* ofonoManager = new QOfonoManager(mController);
+    QString modemPath(ofonoManager->defaultModem());
+    if (!modemPath.isEmpty()) mController->setModemPath(modemPath);
+    connect(ofonoManager, SIGNAL(defaultModemChanged(QString)),
+        mController, SLOT(setModemPath(QString)));
 }
 
 CDSimPlugin::MetaData CDSimPlugin::metaData()

--- a/rpm/contactsd.spec
+++ b/rpm/contactsd.spec
@@ -29,6 +29,7 @@ BuildRequires: buteo-syncfw-qt5-devel >= 0.6.33
 BuildRequires: pkgconfig(qt5-boostable)
 BuildRequires: qt5-qttools
 BuildRequires: qt5-qttools-linguist
+Requires: libqofono-qt5 >= 0.67
 Requires: mapplauncherd-qt5
 
 %description

--- a/tests/ut_simplugin/test-sim-plugin.cpp
+++ b/tests/ut_simplugin/test-sim-plugin.cpp
@@ -580,8 +580,7 @@ void TestSimPlugin::testClear()
 {
     QContactManager &m(m_controller->contactManager());
     // Notify about fake presence of the Phonebook interface
-    QTest::ignoreMessage(QtWarningMsg, "No modem path is configured ");
-    m_controller->interfacesChanged(QStringList(QString::fromLatin1("org.ofono.Phonebook")));
+    m_controller->m_phonebook.onModemInterfacesChanged(QStringList(QString::fromLatin1("org.ofono.Phonebook")));
 
     // Add two contacts manually
     QContact gump;
@@ -606,10 +605,10 @@ void TestSimPlugin::testClear()
     QVERIFY(m.saveContact(&whittaker));
 
     QCOMPARE(getAllSimContacts(m).count(), 2);
-    QCOMPARE(m_controller->busy(), false);
+    QCOMPARE(m_controller->busy(), true);
 
     // Report the phonebook unavailability (happens when SIM card gets removed)
-    m_controller->interfacesChanged(QStringList());
+    m_controller->m_phonebook.onModemInterfacesChanged(QStringList());
     QTRY_VERIFY(m_controller->busy() == false);
 
     // All sim contacts should be removed

--- a/tests/ut_simplugin/test-sim-plugin.h
+++ b/tests/ut_simplugin/test-sim-plugin.h
@@ -19,7 +19,12 @@
 #include <QObject>
 #include <QtTest/QtTest>
 
-#include "../../plugins/sim/cdsimcontroller.h"
+// "unprotect" m_phonebook.onModemInterfacesChanged
+#define private public
+#define protected public
+#include "cdsimcontroller.h"
+#undef private
+#undef protected
 
 class TestSimPlugin : public QObject
 {


### PR DESCRIPTION
Modem list is no longer available immediately after QOfonoManager has been constructed (as a result of elimination of blocking D-Bus calls). One has to wait for modemsChanged or defaultModemChanged signal.

Also, removed QOfonoModem and other unnecessary members from CDSimController, normalized signal and slot names.
