### PR TITLE
[contactsd] Export presence state change information over DBUS

### DIFF
--- a/plugins/telepathy/cdtpcontroller.cpp
+++ b/plugins/telepathy/cdtpcontroller.cpp
@@ -132,6 +132,7 @@ void CDTpController::onAccountManagerReady(Tp::PendingOperation *op)
         insertAccount(account, false);
     }
 
+    mStorage.reportPresenceStates();
     mStorage.syncAccounts(mAccounts.values());
 }
 

--- a/plugins/telepathy/cdtpdevicepresence.cpp
+++ b/plugins/telepathy/cdtpdevicepresence.cpp
@@ -1,0 +1,41 @@
+#include <QDBusConnection>
+
+#include "cdtpdevicepresence.h"
+#include "devicepresenceadaptor.h"
+
+
+namespace {
+
+const QString DEVICE_PRESENCE_OBJECT_PATH = QStringLiteral("/org/nemomobile/DevicePresence");
+const QString DEVICE_PRESENCE_SERVICE_NAME = QStringLiteral("org.nemomobile.DevicePresence");
+
+}
+
+CDTpDevicePresence::CDTpDevicePresence(QObject *parent)
+    : QObject(parent)
+{
+    if (!QDBusConnection::sessionBus().isConnected()) {
+        qCritical() << Q_FUNC_INFO << "ERROR: No DBus session bus found!";
+        return;
+    }
+
+    if (!QDBusConnection::sessionBus().registerObject(DEVICE_PRESENCE_OBJECT_PATH, this)) {
+        qWarning() << Q_FUNC_INFO
+                   << "Object registration failed:" << DEVICE_PRESENCE_OBJECT_PATH
+                   << QDBusConnection::sessionBus().lastError();
+    } else {
+        if (!QDBusConnection::sessionBus().registerService(DEVICE_PRESENCE_SERVICE_NAME)) {
+            qWarning() << Q_FUNC_INFO
+                       << "Unable to register account presence service:" << DEVICE_PRESENCE_SERVICE_NAME
+                       << QDBusConnection::sessionBus().lastError();
+        } else {
+            new DevicePresenceAdaptor(this);
+        }
+    }
+}
+
+CDTpDevicePresence::~CDTpDevicePresence()
+{
+    QDBusConnection::sessionBus().unregisterService(DEVICE_PRESENCE_SERVICE_NAME);
+    QDBusConnection::sessionBus().unregisterObject(DEVICE_PRESENCE_OBJECT_PATH);
+}

--- a/plugins/telepathy/cdtpdevicepresence.h
+++ b/plugins/telepathy/cdtpdevicepresence.h
@@ -1,0 +1,30 @@
+#ifndef CDTPDEVICEPRESENCE_H
+#define CDTPDEVICEPRESENCE_H
+
+#include <QObject>
+
+class CDTpDevicePresence : public QObject
+{
+    Q_OBJECT
+
+public:
+    CDTpDevicePresence(QObject *parent = 0);
+    ~CDTpDevicePresence();
+
+signals:
+    void requestUpdate();
+
+    void accountList(const QStringList &accountPaths);
+    void globalUpdate(int presenceState);
+    void update(const QString &accountPath,
+                const QString &accountUri,
+                const QString &serviceProvider,
+                const QString &serviceProviderDisplayName,
+                const QString &accountDisplayName,
+                const QString &accountIconPath,
+                int presenceState,
+                const QString &presenceMessage,
+                bool enabled);
+};
+
+#endif // CDTPDEVICEPRESENCE_H

--- a/plugins/telepathy/cdtpstorage.h
+++ b/plugins/telepathy/cdtpstorage.h
@@ -40,6 +40,7 @@
 
 QTCONTACTS_USE_NAMESPACE
 
+class CDTpDevicePresence;
 class CDTpStorage : public QObject
 {
     Q_OBJECT
@@ -63,6 +64,7 @@ public Q_SLOTS:
             const QList<CDTpContactPtr> &contactsAdded,
             const QList<CDTpContactPtr> &contactsRemoved);
     void updateContact(CDTpContactPtr contactWrapper, CDTpContact::Changes changes);
+    void reportPresenceStates();
 
 public:
     void createAccountContacts(CDTpAccountPtr accountWrapper, const QStringList &imIds, uint localId);
@@ -95,6 +97,7 @@ private:
     QTimer mUpdateTimer;
     QElapsedTimer mWaitTimer;
     QMap<QString, CDTpAccount::Changes> m_accountPendingChanges;
+    CDTpDevicePresence *mDevicePresence;
 };
 
 #endif // CDTPSTORAGE_H

--- a/plugins/telepathy/org.nemomobile.DevicePresenceIf.xml
+++ b/plugins/telepathy/org.nemomobile.DevicePresenceIf.xml
@@ -1,0 +1,27 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+    <interface name="org.nemomobile.DevicePresenceIf">
+        <signal name="accountList">
+            <arg name="accountPaths" type="as"/>
+        </signal>
+        <signal name="update">
+            <arg name="accountPath" type="s"/>
+            <arg name="accountUri" type="s"/>
+            <arg name="serviceProvider" type="s"/>
+            <arg name="serviceProviderDisplayName" type="s"/>
+            <arg name="accountDisplayName" type="s"/>
+            <arg name="iconPath" type="s"/>
+            <arg name="presenceState" type="i"/>
+            <arg name="presenceMessage" type="s"/>
+            <arg name="enabled" type="b"/>
+        </signal>
+        <signal name="globalUpdate">
+            <arg name="presenceState" type="i"/>
+        </signal>
+        <method name="requestUpdate">
+        </method>
+    </interface>
+</node>
+
+

--- a/plugins/telepathy/telepathy.pro
+++ b/plugins/telepathy/telepathy.pro
@@ -30,7 +30,8 @@ CONFIG += c++11
 PKGCONFIG += Qt5Contacts
 PKGCONFIG += TelepathyQt5 qtcontacts-sqlite-qt5-extensions
 
-system(qdbusxml2cpp -c BuddyManagementAdaptor -a buddymanagementadaptor.h:buddymanagementadaptor.cpp com.nokia.contacts.buddymanagement.xml)
+system(qdbusxml2cpp -c BuddyManagementAdaptor -a buddymanagementadaptor com.nokia.contacts.buddymanagement.xml)
+system(qdbusxml2cpp -c DevicePresenceAdaptor -a devicepresenceadaptor org.nemomobile.DevicePresenceIf.xml)
 
 CONFIG(coverage):{
 QMAKE_CXXFLAGS += -c -g  --coverage -ftest-coverage -fprofile-arcs
@@ -49,9 +50,11 @@ HEADERS  = cdtpaccount.h \
     types.h \
     cdtpcontact.h \
     cdtpcontroller.h \
+    cdtpdevicepresence.h \
     cdtpplugin.h \
     cdtpstorage.h \
     buddymanagementadaptor.h \
+    devicepresenceadaptor.h \
     cdtpavatarupdate.h
 
 SOURCES  = cdtpaccount.cpp \
@@ -59,9 +62,11 @@ SOURCES  = cdtpaccount.cpp \
     cdtpaccountcachewriter.cpp \
     cdtpcontact.cpp \
     cdtpcontroller.cpp \
+    cdtpdevicepresence.cpp \
     cdtpplugin.cpp \
     cdtpstorage.cpp \
     buddymanagementadaptor.cpp \
+    devicepresenceadaptor.cpp \
     cdtpavatarupdate.cpp
 
 VERSIONED_PACKAGENAME=contactsd-1.0
@@ -75,4 +80,5 @@ xml.path = $$INCLUDEDIR/$${VERSIONED_PACKAGENAME}
 INSTALLS += target xml
 
 OTHER_FILES += \
+    org.nemomobile.DevicePresenceIf.xml \
     com.nokia.contacts.buddymanagement.xml


### PR DESCRIPTION
Interested parties can use the org.nemomobile.DevicePresenceIf
interface to observe changes to device presence state, without
having to use the QtContacts interface to retrieve the data.