### PR TITLE
[contactsd] Add support for automatically triggering syncs

### DIFF
--- a/src/src.pro
+++ b/src/src.pro
@@ -26,6 +26,7 @@ TARGET = contactsd
 VERSIONED_TARGET = $$TARGET-1.0
 
 QT += dbus
+QT += contacts
 QT -= gui
 
 system(qdbusxml2cpp -c ContactsImportProgressAdaptor -a contactsimportprogressadaptor.h:contactsimportprogressadaptor.cpp com.nokia.contacts.importprogress.xml)

--- a/src/synctrigger.h
+++ b/src/synctrigger.h
@@ -24,6 +24,10 @@
 #include <QDBusConnection>
 #include <QObject>
 #include <QStringList>
+#include <QTimer>
+
+#include <QContactManager>
+QTCONTACTS_USE_NAMESPACE
 
 namespace Contactsd {
 
@@ -51,7 +55,13 @@ public:
 public Q_SLOTS:
     Q_NOREPLY void triggerSync(const QStringList &syncTargets = QStringList(), int syncPolicy = ForceSync, int directionPolicy = AnyDirection);
 
+private Q_SLOTS:
+    void contactDbChangesDetected();
+    void coalescedTrigger();
+
 private:
+    QTimer mTimer;
+    QContactManager *mContactManager;
     QDBusConnection *mDBusConnection;
     bool mHaveRegisteredDBus;
 };


### PR DESCRIPTION
This commit adds support to automatically trigger syncs when local
database modifications are detected.  It coalesces change signals
emitted within one minute in order to minimise sync activity.