### PR TITLE
[contactsd] Sync all targets unconditionally on contact change

### DIFF
--- a/plugins/exporter/cdexportercontroller.h
+++ b/plugins/exporter/cdexportercontroller.h
@@ -62,6 +62,8 @@ private:
     MGConfItem m_disabledConf;
     MGConfItem m_debugConf;
     MGConfItem m_importConf;
+
+    bool m_syncAllTargets;
 };
 
 #endif // CDEXPORTERCONTROLLER_H

--- a/src/synctrigger.cpp
+++ b/src/synctrigger.cpp
@@ -111,6 +111,7 @@ void SyncTrigger::triggerSync(const QStringList &syncTargets, int syncPolicy, in
         if (notTemplate && isEnabled && isTarget && isContacts
                 && (isUpsync || directionPolicy == SyncTrigger::AnyDirection)
                 && (alwaysUpToDate || syncPolicy == SyncTrigger::ForceSync)) {
+            debug() << "SyncTrigger: profile meets criteria, triggering:" << profileId;
             QDBusMessage message = QDBusMessage::createMethodCall(
                     QStringLiteral("com.meego.msyncd"),
                     QStringLiteral("/synchronizer"),


### PR DESCRIPTION
This commit ensures that local contact changes cause sync to
be triggered for all sync targets unconditionally.
Previously, pure-local additions (or subsequent modifications or
removals) would not trigger sync because they were not associated
with any sync target, and hence wouldn't be included in the
syncContactsChanged() signal from qtcontacts-sqlite.