### PR TITLE
[contactsd] Adaptively rate-limit sync triggers. Contributes to MER#1074

### DIFF
--- a/plugins/exporter/cdexportercontroller.h
+++ b/plugins/exporter/cdexportercontroller.h
@@ -63,6 +63,9 @@ private:
     MGConfItem m_debugConf;
     MGConfItem m_importConf;
 
+    uint m_lastSyncTimestamp;
+    int m_adaptiveSyncDelay;
+
     bool m_syncAllTargets;
 };
 


### PR DESCRIPTION
This commit adds adaptive rate-limiting to sync triggering, to avoid
the possibility of many syncs being triggered due to sync updates,
in a cyclic fashion.

Contributes to MER#1074