### PR TITLE
[contactsd] Use separate timers for export vs remote sync. Contributes to MER#1134

### DIFF
--- a/plugins/exporter/cdexportercontroller.h
+++ b/plugins/exporter/cdexportercontroller.h
@@ -49,6 +49,7 @@ private slots:
     void onSyncContactsChanged(const QStringList &syncTargets);
 
     void onSyncTimeout();
+    void onExportTimeout();
 
 private:
     enum ChangeType { PresenceChange, DataChange };
@@ -57,6 +58,7 @@ private:
     QContactManager m_privilegedManager;
     QContactManager m_nonprivilegedManager;
     QTimer m_syncTimer;
+    QTimer m_exportTimer;
     QSet<QString> m_syncTargetsNeedingSync;
 
     MGConfItem m_disabledConf;


### PR DESCRIPTION
This commit ensures that we use separate heuristics for determining
whether and when to trigger export syncs and remote syncs.

Contributes to MER#1134